### PR TITLE
Disable automatic catchup locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       AIRFLOW__CELERY__RESULT_BACKEND: "db+postgresql://postgres@db/postgres"
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://postgres@db/postgres"
       AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: 30
+      AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT: "False"
       AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
       AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION}"
@@ -38,6 +39,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://postgres@db/postgres"
       AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: 30
+      AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT: "False"
       AIRFLOW__CORE__EXECUTOR: "CeleryExecutor"
       AIRFLOW__CELERY__BROKER_URL: "redis://redis:6379"
       AIRFLOW__CELERY__RESULT_BACKEND: "db+postgresql://postgres@db/postgres"
@@ -63,6 +65,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://postgres@db/postgres"
       AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL: 30
+      AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT: "False"
       AIRFLOW__CORE__EXECUTOR: "CeleryExecutor"
       AIRFLOW__CELERY__BROKER_URL: "redis://redis:6379"
       AIRFLOW__CELERY__RESULT_BACKEND: "db+postgresql://postgres@db/postgres"


### PR DESCRIPTION
This is already done in staging/production. I'm just adding the
configuration to the compose file to avoid unnecessary backfills in
development. This seems like the behavior we would usually want, but it
can always be disabled on a case-by-case basis by explicitly turning on
catchup in the DAG.

## How can a reviewer see these changes?

Create a DAG with a dummy operator. Give the DAG a `start_date` of several days in the past. Start up your local Airflow instance, enable the dag and see that the scheduler has only scheduled a single instance of the DAG.

## Reviewer Checklist
- [x] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
