### PR TITLE
Build default service names

### DIFF
--- a/manager/cli.py
+++ b/manager/cli.py
@@ -11,13 +11,13 @@ from manager.cluster import Cluster, ecs_model
 @click.group()
 @click.option('--cluster', default='airflow-stage',
               help='Fargate cluster name. Defaults to airflow-stage.')
-@click.option('--scheduler', default='airflow-stage-scheduler',
+@click.option('--scheduler',
               help='Name of scheduler service. Defaults to '
-                   'airflow-stage-scheduler.')
-@click.option('--worker', default='airflow-stage-worker',
-              help='Name of worker service. Defaults to airflow-stage-worker.')
-@click.option('--web', default='airflow-stage-web',
-              help='Name of web service. Defaults to airflow-stage-web.')
+                   'CLUSTER-scheduler.')
+@click.option('--worker',
+              help='Name of worker service. Defaults to CLUSTER-worker.')
+@click.option('--web',
+              help='Name of web service. Defaults to CLUSTER-web.')
 @click.pass_context
 def main(ctx, cluster, scheduler, worker, web):
     """Run one-off tasks on a Fargate Airflow cluster.
@@ -32,7 +32,18 @@ def main(ctx, cluster, scheduler, worker, web):
 
     The tool only schedules a task to be run. Check the AWS console to see
     if the container ran successfully.
+
+    The three options for specifying service names should not generally be
+    necessary. Our naming is consistent and predictable across staging
+    and production. Simply specifying the cluster name should be enough to
+    infer the correct service names.
     """
+    if not scheduler:
+        scheduler = f'{cluster}-scheduler'
+    if not worker:
+        worker = f'{cluster}-worker'
+    if not web:
+        web = f'{cluster}-web'
     ecs = boto3.client('ecs')
     cluster = Cluster(cluster, scheduler, worker, web, ecs)
     ctx.ensure_object(dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ def cluster():
     Also see the ``patch_cluster_config`` fixture below.
     """
     C = namedtuple('C', ['name', 'scheduler', 'worker', 'web'])
-    cluster = C('airflow-test', 'scheduler', 'worker', 'web')
+    cluster = C('airflow-test', 'airflow-test-scheduler',
+                'airflow-test-worker', 'airflow-test-web')
     with mock_ecs(), mock_ec2():
         ec2_client = boto3.client('ec2')
         ec2 = boto3.resource('ec2')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,3 +106,11 @@ def test_starts_scheduler(cluster, cluster_opts):
             'start-scheduler',
             '--no-wait'])
     assert 'Starting scheduler...' in res.output
+
+
+def test_uses_default_service_name(cluster):
+    res = CliRunner().invoke(main, [
+            '--cluster', cluster.name,
+            'stop-scheduler',
+            '--yes'])
+    assert 'Stopping scheduler...OK' in res.output

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -6,7 +6,8 @@ from manager.cluster import Cluster
 
 def test_run_task_returns_taskarn(cluster):
     ecs = boto3.client('ecs')
-    c = Cluster('airflow-test', 'scheduler', 'worker', 'web', ecs)
+    c = Cluster('airflow-test', 'airflow-test-scheduler',
+                'airflow-test-worker', 'airflow-test-web', ecs)
     assert c.run_task({'command': ['run_things']})\
         .startswith('arn:aws:ecs:us-east-1:012345678910:task/')
 


### PR DESCRIPTION
This changes behavior of the workflow command to build the service names
from the cluster name. The options remain and can still be used to
override this default behavior if needed. This should save a lot of
typing and potential mistakes.

Closes #20.

## How can a reviewer see these changes?

The only way to really see the change would be to run a command on the production cluster. Or you can just trust my tests...

## Reviewer Checklist
- [x] The commit message is clear and follows our guidelines
- [x] There are tests covering any new functionality
- [x] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
