### PR TITLE
Ignores security warning for tornado

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ flake8:
 	pipenv run flake8 manager tests mit
 
 safety:
-	pipenv check
+	pipenv check --ignore 39462
 
 check: flake8 safety ## Run linting, security checks
 


### PR DESCRIPTION
Why are these changes being introduced:

* our process fails when a vulnerability is found
* merging with failing tests is bad
* there is no fix for this upstream
* we are not vulnerable to the concern in the CVE

How does this address that need:

* adds an ignore to the pipenv check for the one vulnerability we have
  determined is not a concern in our environment that was failing our
  tests

## How can a reviewer see these changes?

The tests should now pass.

## Reviewer Checklist
- [x] The commit message is clear and follows our guidelines
- [ ] There are tests covering any new functionality
- [ ] The documentation has been updated if necessary
- [ ] The changes, if applicable, have been verified
